### PR TITLE
WFCORE-1881 / WFCORE-1882

### DIFF
--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyKernelServicesImpl.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyKernelServicesImpl.java
@@ -212,6 +212,11 @@ public class LegacyKernelServicesImpl extends AbstractKernelServicesImpl {
             }
 
             @Override
+            public boolean isCandidateDomainController() {
+                return false;
+            }
+
+            @Override
             public String getRemoteDomainControllerUsername() {
                 return null;
             }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/DomainController.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/DomainController.java
@@ -24,6 +24,7 @@ package org.jboss.as.domain.controller;
 
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.transform.Transformers;
+import org.jboss.as.host.controller.mgmt.HostInfo;
 import org.jboss.as.protocol.mgmt.ManagementChannelHandler;
 import org.jboss.as.repository.HostFileRepository;
 
@@ -38,16 +39,15 @@ public interface DomainController extends HostRegistrations {
      * Registers a slave Host Controller with this domain controller.
      *
      *
-     * @param hostName the name of the slave host
+     * @param hostInfo the slave's registration info
      * @param handler  handler for communications with the host
      * @param transformers transformation handler for converting resources and operations to forms appropriate for the slave
-     * @param remoteConnectionId long identifying this specific connection to the host, or {@code null} if the host did not provide such an id
      * @param registerProxyController {@code true} if a proxy controller should be registered for the host; {@code false}
      *                                             if the host is in --admin-only mode and should not be visible to outside users
      * @throws SlaveRegistrationException  if there is a problem registering the host
      */
-    void registerRemoteHost(final String hostName, final ManagementChannelHandler handler, final Transformers transformers,
-                            Long remoteConnectionId, boolean registerProxyController) throws SlaveRegistrationException;
+    void registerRemoteHost(final HostInfo hostInfo, final ManagementChannelHandler handler, final Transformers transformers,
+                            boolean registerProxyController) throws SlaveRegistrationException;
 
     /**
      * Check if a Host Controller is already registered with this domain controller.

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/LocalHostControllerInfo.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/LocalHostControllerInfo.java
@@ -54,6 +54,15 @@ public interface LocalHostControllerInfo {
      boolean isMasterDomainController();
 
     /**
+     * Whether we are configured to be eligible to be elected master domain controller.
+     *
+     * @return {@code true} if the local host controller is configured to be a candidate domain controller (CDC)
+     *
+     * @throws IllegalStateException if {@link #getProcessState()} is {@link org.jboss.as.controller.ControlledProcessState.State#STARTING}
+     */
+    boolean isCandidateDomainController();
+
+    /**
      * Whether we are acting as a backup DC or not (started with the --backup option)
      *
      * @return {@code true} if we intend to be able to take over as DC

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/SlaveRegistrationException.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/SlaveRegistrationException.java
@@ -70,6 +70,10 @@ public class SlaveRegistrationException extends Exception {
         return new SlaveRegistrationException(ErrorCode.HOST_ALREADY_EXISTS, DomainControllerLogger.ROOT_LOGGER.slaveControllerCannotAcceptOtherSlaves());
     }
 
+    public static SlaveRegistrationException forMasterIsOlderVersionThanSlave() {
+        return new SlaveRegistrationException(ErrorCode.INCOMPATIBLE_VERSION, DomainControllerLogger.ROOT_LOGGER.slaveControllerIsNewerVersionThanMaster());
+    }
+
     public String marshal() {
         return errorCode.getCode() + SEPARATOR + errorMessage;
     }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/logging/DomainControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/logging/DomainControllerLogger.java
@@ -802,4 +802,13 @@ public interface DomainControllerLogger extends BasicLogger {
 
     @Message(id = 97, value = "Cannot explode a subdeployment of an unexploded deployment")
     OperationFailedException cannotExplodeSubDeploymentOfUnexplodedDeployment();
+
+    /**
+     * Creates an exception message indicating the registering slave is a new API release than the current master,
+     * and is not allowed to register.
+     *
+     * @return a message for the error.
+     */
+    @Message(id = 98, value = "Domain Controller software API version is older than slave API version. Newer API version slaves may not be registered with older API version domain controllers.")
+    String slaveControllerIsNewerVersionThanMaster();
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/logging/DomainControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/logging/DomainControllerLogger.java
@@ -809,6 +809,6 @@ public interface DomainControllerLogger extends BasicLogger {
      *
      * @return a message for the error.
      */
-    @Message(id = 98, value = "Domain Controller software API version is older than slave API version. Newer API version slaves may not be registered with older API version domain controllers.")
+    @Message(id = 98, value = "Domain Controller management API version is older than slave management API version. Newer API version slaves may not be registered with older API version domain controllers.")
     String slaveControllerIsNewerVersionThanMaster();
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ProfileCloneHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ProfileCloneHandler.java
@@ -80,7 +80,8 @@ public class ProfileCloneHandler implements OperationStepHandler {
         final PathAddress address = PathAddress.pathAddress(PathElement.pathElement(PROFILE, profileName));
         final PathAddress newPA = PathAddress.pathAddress(PROFILE, newProfile);
 
-        if (!hostInfo.isMasterDomainController()) {
+        // for both master and CDC cases, we can't ignore anything.
+        if (! (hostInfo.isMasterDomainController() || hostInfo.isCandidateDomainController())) {
             if (ignoredDomainResourceRegistry.isResourceExcluded(address) || ignoredDomainResourceRegistry.isResourceExcluded(newPA)) {
                 return;
             }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -82,6 +82,7 @@ import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.ModelController;
 import org.jboss.as.controller.ModelController.OperationTransactionControl;
 import org.jboss.as.controller.ModelControllerServiceInitialization;
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
@@ -132,6 +133,7 @@ import org.jboss.as.host.controller.ignored.IgnoredDomainResourceRegistry;
 import org.jboss.as.host.controller.logging.HostControllerLogger;
 import org.jboss.as.host.controller.mgmt.DomainHostExcludeRegistry;
 import org.jboss.as.host.controller.mgmt.HostControllerOperationExecutor;
+import org.jboss.as.host.controller.mgmt.HostInfo;
 import org.jboss.as.host.controller.mgmt.MasterDomainControllerOperationHandlerService;
 import org.jboss.as.host.controller.mgmt.ServerToHostOperationHandlerFactoryService;
 import org.jboss.as.host.controller.mgmt.ServerToHostProtocolHandler;
@@ -326,8 +328,8 @@ public class DomainModelControllerService extends AbstractControllerService impl
     }
 
     @Override
-    public void registerRemoteHost(final String hostName, final ManagementChannelHandler handler, final Transformers transformers,
-                                   final Long remoteConnectionId, final boolean registerProxyController) throws SlaveRegistrationException {
+    public void registerRemoteHost(final HostInfo hostInfo, final ManagementChannelHandler handler, final Transformers transformers,
+                                   final boolean registerProxyController) throws SlaveRegistrationException {
         if (!hostControllerInfo.isMasterDomainController()) {
             throw SlaveRegistrationException.forHostIsNotMaster();
         }
@@ -336,6 +338,12 @@ public class DomainModelControllerService extends AbstractControllerService impl
             throw SlaveRegistrationException.forMasterInAdminOnlyMode(runningModeControl.getRunningMode());
         }
 
+        // verify the registering slave is not a newer API version than the current master.
+        if (!slaveRegistrationVersionOk(ModelVersion.CURRENT, hostInfo)) {
+            throw SlaveRegistrationException.forMasterIsOlderVersionThanSlave();
+        }
+
+        final String hostName = hostInfo.getHostName();
         final PathElement pe = PathElement.pathElement(ModelDescriptionConstants.HOST, hostName);
         final PathAddress addr = PathAddress.pathAddress(pe);
         ProxyController existingController = modelNodeRegistration.getProxyController(addr);
@@ -344,7 +352,7 @@ public class DomainModelControllerService extends AbstractControllerService impl
             throw SlaveRegistrationException.forHostAlreadyExists(pe.getValue());
         }
 
-        final SlaveHostPinger pinger = remoteConnectionId == null ? null : new SlaveHostPinger(hostName, handler, pingScheduler, remoteConnectionId);
+        final SlaveHostPinger pinger = hostInfo.getRemoteConnectionId() == null ? null : new SlaveHostPinger(hostName, handler, pingScheduler, hostInfo.getRemoteConnectionId());
         final String address = handler.getRemoteAddress().getHostAddress();
         slaveHostRegistrations.recordLocalHostRegistration(hostName, pinger, address);
 
@@ -924,6 +932,21 @@ public class DomainModelControllerService extends AbstractControllerService impl
         DomainRootDefinition domainRootDefinition = new DomainRootDefinition(environment, configurationPersister, contentRepo, fileRepository, isMaster, hostControllerInfo,
                 extensionRegistry, ignoredDomainResourceRegistry, authorizer, this, domainHostExcludeRegistry, getMutableRootResourceRegistrationProvider());
         rootResourceDefinition.setDelegate(domainRootDefinition, root);
+    }
+
+    private boolean slaveRegistrationVersionOk(final ModelVersion masterVersion, final HostInfo slaveHostInfo) {
+        assert masterVersion != null;
+        assert slaveHostInfo != null;
+        if (masterVersion.getMajor() < slaveHostInfo.getManagementMajorVersion()) {
+            return false;
+        }
+        if (masterVersion.getMinor() < slaveHostInfo.getManagementMinorVersion()) {
+            return false;
+        }
+        if (masterVersion.getMicro() < slaveHostInfo.getManagementMicroVersion()) {
+            return false;
+        }
+        return true;
     }
 
     private class DelegatingServerInventory implements ServerInventory {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -337,12 +337,10 @@ public class DomainModelControllerService extends AbstractControllerService impl
         if (runningModeControl.getRunningMode() == RunningMode.ADMIN_ONLY) {
             throw SlaveRegistrationException.forMasterInAdminOnlyMode(runningModeControl.getRunningMode());
         }
-
         // verify the registering slave is not a newer API version than the current master.
         if (!slaveRegistrationVersionOk(ModelVersion.CURRENT, hostInfo)) {
             throw SlaveRegistrationException.forMasterIsOlderVersionThanSlave();
         }
-
         final String hostName = hostInfo.getHostName();
         final PathElement pe = PathElement.pathElement(ModelDescriptionConstants.HOST, hostName);
         final PathAddress addr = PathAddress.pathAddress(pe);
@@ -805,16 +803,15 @@ public class DomainModelControllerService extends AbstractControllerService impl
                             CommandLineConstants.CACHED_DC);
 
                 }
-                SystemExiter.abort(ExitCodes.HOST_CONTROLLER_ABORT_EXIT_CODE);
-                // If we got here, the Exiter didn't really exit. Must be embedded.
-                // Inform the caller so it knows not to proceed with boot.
+                // this returns ABORT to the caller, indicating the the DC is not available
+                // and boot (in the non --cached-dc case), should not continue.
                 return DomainConnectResult.ABORT;
             } else if (currentRunningMode != RunningMode.ADMIN_ONLY) {
                 // Register a service that will try again once we reach RUNNING state
                 DeferredDomainConnectService.install(serviceTarget, masterDomainControllerClient);
             }
-            return DomainConnectResult.FAILED;
         }
+        return DomainConnectResult.FAILED;
     }
 
     void disconnectFromMaster(ServiceContainer serviceContainer) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -934,16 +934,19 @@ public class DomainModelControllerService extends AbstractControllerService impl
     private boolean slaveRegistrationVersionOk(final ModelVersion masterVersion, final HostInfo slaveHostInfo) {
         assert masterVersion != null;
         assert slaveHostInfo != null;
-        if (masterVersion.getMajor() < slaveHostInfo.getManagementMajorVersion()) {
-            return false;
+        if (masterVersion.getMajor() > slaveHostInfo.getManagementMajorVersion()) {
+            return true;
         }
-        if (masterVersion.getMinor() < slaveHostInfo.getManagementMinorVersion()) {
-            return false;
+        if (masterVersion.getMajor() == slaveHostInfo.getManagementMajorVersion() &&
+                masterVersion.getMinor() > slaveHostInfo.getManagementMinorVersion()) {
+            return true;
         }
-        if (masterVersion.getMicro() < slaveHostInfo.getManagementMicroVersion()) {
-            return false;
+        if (masterVersion.getMajor() == slaveHostInfo.getManagementMajorVersion() &&
+                masterVersion.getMinor() == slaveHostInfo.getManagementMinorVersion() &&
+                masterVersion.getMicro() >= slaveHostInfo.getManagementMicroVersion()) {
+            return true;
         }
-        return true;
+        return false;
     }
 
     private class DelegatingServerInventory implements ServerInventory {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ignored/IgnoredDomainResourceRoot.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ignored/IgnoredDomainResourceRoot.java
@@ -82,7 +82,7 @@ class IgnoredDomainResourceRoot implements Resource.ResourceEntry {
     @Override
     public boolean hasChild(PathElement element) {
         synchronized (children) {
-            return !isMaster() && IGNORED_RESOURCE_TYPE.equals(element.getKey())
+            return !isDomainController() && IGNORED_RESOURCE_TYPE.equals(element.getKey())
                     && children.containsKey(element.getValue());
         }
     }
@@ -90,7 +90,7 @@ class IgnoredDomainResourceRoot implements Resource.ResourceEntry {
     @Override
     public Resource getChild(PathElement element) {
         Resource result = null;
-        if (!isMaster() && IGNORED_RESOURCE_TYPE.equals(element.getKey())) {
+        if (!isDomainController() && IGNORED_RESOURCE_TYPE.equals(element.getKey())) {
             result = getChildInternal(element.getValue());
         }
         return result;
@@ -107,7 +107,7 @@ class IgnoredDomainResourceRoot implements Resource.ResourceEntry {
 
     @Override
     public boolean hasChildren(String childType) {
-        boolean result = !isMaster() && IGNORED_RESOURCE_TYPE.equals(childType);
+        boolean result = !isDomainController() && IGNORED_RESOURCE_TYPE.equals(childType);
         if (result) {
             synchronized (children) {
                 result = children.size() > 0;
@@ -129,7 +129,7 @@ class IgnoredDomainResourceRoot implements Resource.ResourceEntry {
     @Override
     public Set<String> getChildrenNames(String childType) {
         Set<String> result;
-        if (!isMaster() && IGNORED_RESOURCE_TYPE.equals(childType)) {
+        if (!isDomainController() && IGNORED_RESOURCE_TYPE.equals(childType)) {
             synchronized (children) {
                 result = new HashSet<String>(children.keySet());
             }
@@ -142,7 +142,7 @@ class IgnoredDomainResourceRoot implements Resource.ResourceEntry {
     @Override
     public Set<ResourceEntry> getChildren(String childType) {
         Set<ResourceEntry> result;
-        if (!isMaster() && IGNORED_RESOURCE_TYPE.equals(childType)) {
+        if (!isDomainController() && IGNORED_RESOURCE_TYPE.equals(childType)) {
             synchronized (children) {
                 result = new HashSet<ResourceEntry>(children.values());
             }
@@ -154,7 +154,7 @@ class IgnoredDomainResourceRoot implements Resource.ResourceEntry {
 
     @Override
     public void registerChild(PathElement address, Resource resource) {
-        if (!isMaster() && IGNORED_RESOURCE_TYPE.equals(address.getKey())) {
+        if (!isDomainController() && IGNORED_RESOURCE_TYPE.equals(address.getKey())) {
             synchronized (children) {
                 if (children.containsKey(address.getValue())) {
                     throw ControllerLogger.ROOT_LOGGER.duplicateResource(address.getValue());
@@ -220,8 +220,8 @@ class IgnoredDomainResourceRoot implements Resource.ResourceEntry {
         children.put(child.getName(), child);
     }
 
-    private boolean isMaster() {
-        return ignoredRegistry.isMaster();
+    private boolean isDomainController() {
+        return ignoredRegistry.isDomainController();
     }
 
     @Override

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostControllerRegistrationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostControllerRegistrationHandler.java
@@ -471,9 +471,8 @@ public class HostControllerRegistrationHandler implements ManagementRequestHandl
             //
             if (sendResultToHost(transaction, result)) return;
             synchronized (this) {
-                Long pingPongId = hostInfo.getRemoteConnectionId();
                 // Register the slave
-                domainController.registerRemoteHost(hostName, handler, transformers, pingPongId, registerProxyController);
+                domainController.registerRemoteHost(hostInfo, handler, transformers, registerProxyController);
                 // Complete registration
                 if(! failed) {
                     transaction.commit();

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/LocalHostControllerInfoImpl.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/LocalHostControllerInfoImpl.java
@@ -42,6 +42,8 @@ public class LocalHostControllerInfoImpl implements LocalHostControllerInfo {
 
     private final String localHostName;
     private volatile boolean master;
+    private volatile boolean candidateDomainController;
+
     private volatile String nativeManagementInterface;
     private volatile int nativeManagementPort;
 
@@ -83,6 +85,11 @@ public class LocalHostControllerInfoImpl implements LocalHostControllerInfo {
         return master;
     }
 
+    @Override
+    public boolean isCandidateDomainController() {
+        // XXX change to actual config value.
+        return isMasterDomainController();
+    }
     @Override
     public String getNativeManagementInterface() {
         return nativeManagementInterface;
@@ -160,6 +167,9 @@ public class LocalHostControllerInfoImpl implements LocalHostControllerInfo {
         this.master = master;
     }
 
+    void setCandidateDomainController(boolean isCandidateDomainController) {
+        this.candidateDomainController = isCandidateDomainController;
+    }
     void setNativeManagementInterface(String nativeManagementInterface) {
         this.nativeManagementInterface = nativeManagementInterface;
     }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/LocalHostControllerInfoImpl.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/LocalHostControllerInfoImpl.java
@@ -87,8 +87,7 @@ public class LocalHostControllerInfoImpl implements LocalHostControllerInfo {
 
     @Override
     public boolean isCandidateDomainController() {
-        // XXX change to actual config value.
-        return isMasterDomainController();
+        return candidateDomainController;
     }
     @Override
     public String getNativeManagementInterface() {

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
@@ -118,6 +118,11 @@ public abstract class AbstractOperationTestCase {
         }
 
         @Override
+        public boolean isCandidateDomainController() {
+            return false;
+        }
+
+        @Override
         public String getNativeManagementInterface() {
             return null;
         }

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
@@ -96,50 +96,90 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
 
     @Test
     public void testAddServerConfigMaster() throws Exception {
-        testAddServerConfig(true, false);
+        testAddServerConfig(true, false, false);
+    }
+
+    @Test
+    public void testAddServerConfigMasterCdc() throws Exception {
+        testAddServerConfig(true, true, false);
     }
 
     @Test
     public void testAddServerConfigSlave() throws Exception {
-        testAddServerConfig(false, false);
+        testAddServerConfig(false, false, false);
+    }
+
+    @Test
+    public void testAddServerConfigCdc() throws Exception {
+        testAddServerConfig(false, true, false);
     }
 
     @Test
     public void testAddServerConfigMasterRollback() throws Exception {
-        testAddServerConfig(true, true);
+        testAddServerConfig(true, false, true);
+    }
+
+    @Test
+    public void testAddServerConfigMasterCDCRollback() throws Exception {
+        testAddServerConfig(true, true, true);
+    }
+
+    @Test
+    public void testAddServerConfigCdcRollback() throws Exception {
+        testAddServerConfig(false, true, true);
     }
 
     @Test
     public void testAddServerConfigSlaveRollback() throws Exception {
-        testAddServerConfig(false, true);
+        testAddServerConfig(false, false, true);
     }
 
-    private void testAddServerConfig(boolean master, boolean rollback) throws Exception {
-        testAddServerConfigBadInfo(master, rollback, false, SocketBindingGroupOverrideType.GOOD);
+    private void testAddServerConfig(boolean master, boolean candidateDomainController, boolean rollback) throws Exception {
+        testAddServerConfigBadInfo(master, candidateDomainController, rollback, false, SocketBindingGroupOverrideType.GOOD);
     }
 
     @Test
     public void testAddServerConfigNoSocketBindingGroupOverrideMaster() throws Exception {
-        testAddServerConfigNoSocketBindingGroupOverride(true, false);
+        testAddServerConfigNoSocketBindingGroupOverride(true, false, false);
+    }
+
+    @Test
+    public void testAddServerConfigNoSocketBindingGroupOverrideMasterCdc() throws Exception {
+        testAddServerConfigNoSocketBindingGroupOverride(true, true, false);
     }
 
     @Test
     public void testAddServerConfigNoSocketBindingGroupOverrideSlave() throws Exception {
-        testAddServerConfigNoSocketBindingGroupOverride(false, false);
+        testAddServerConfigNoSocketBindingGroupOverride(false, false, false);
+    }
+
+    @Test
+    public void testAddServerConfigNoSocketBindingGroupOverrideCdc() throws Exception {
+        testAddServerConfigNoSocketBindingGroupOverride(false, true, false);
     }
 
     @Test
     public void testAddServerConfigNoSocketBindingGroupOverrideMasterRollback() throws Exception {
-        testAddServerConfigNoSocketBindingGroupOverride(true, true);
+        testAddServerConfigNoSocketBindingGroupOverride(true, true, true);
+    }
+
+    @Test
+    public void testAddServerConfigNoSocketBindingGroupOverrideMasterCdcRollback() throws Exception {
+        testAddServerConfigNoSocketBindingGroupOverride(true, true, true);
     }
 
     @Test
     public void testAddServerConfigNoSocketBindingGroupOverrideSlaveRollback() throws Exception {
-        testAddServerConfigNoSocketBindingGroupOverride(false, true);
+        testAddServerConfigNoSocketBindingGroupOverride(false, false, true);
     }
 
-    private void testAddServerConfigNoSocketBindingGroupOverride(boolean master, boolean rollback) throws Exception {
-        testAddServerConfigBadInfo(master, rollback, false, SocketBindingGroupOverrideType.NONE);
+    @Test
+    public void testAddServerConfigNoSocketBindingGroupOverrideCdcRollback() throws Exception {
+        testAddServerConfigNoSocketBindingGroupOverride(false, true, true);
+    }
+
+    private void testAddServerConfigNoSocketBindingGroupOverride(boolean master, boolean candidateDomainController, boolean rollback) throws Exception {
+        testAddServerConfigBadInfo(master, candidateDomainController, rollback, false, SocketBindingGroupOverrideType.NONE);
     }
 
 //    // WFCORE-833 moved to ServerConfigTestCase.testAddServerConfigBadServerGroup()
@@ -192,7 +232,7 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
 //        testAddServerConfigBadInfo(false, true, false, SocketBindingGroupOverrideType.BAD);
 //    }
 
-    private void testAddServerConfigBadInfo(boolean master, boolean rollback, boolean badServerGroup, SocketBindingGroupOverrideType socketBindingGroupOverride) throws Exception {
+    private void testAddServerConfigBadInfo(boolean master, boolean candidateDomainController, boolean rollback, boolean badServerGroup, SocketBindingGroupOverrideType socketBindingGroupOverride) throws Exception {
         PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(HOST, "localhost"), PathElement.pathElement(SERVER_CONFIG, "server-four"));
         final MockOperationContext operationContext = getOperationContext(rollback, pa);
 
@@ -215,7 +255,7 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
         }
 
         try {
-            operationContext.executeStep(ServerAddHandler.create(new MockHostControllerInfo(master), new ServerInventoryMock(), new ControlledProcessState(false), new File(System.getProperty("java.io.tmpdir"))), operation);
+            operationContext.executeStep(ServerAddHandler.create(new MockHostControllerInfo(master, candidateDomainController), new ServerInventoryMock(), new ControlledProcessState(false), new File(System.getProperty("java.io.tmpdir"))), operation);
         } catch (RuntimeException e) {
             final Throwable t = e.getCause();
             if (t instanceof OperationFailedException) {
@@ -234,25 +274,45 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
 
     @Test
     public void testRemoveServerConfigMaster() throws Exception {
-        testRemoveServerConfig(true, false);
+        testRemoveServerConfig(true, false, false);
+    }
+
+    @Test
+    public void testRemoveServerConfigMasterCdc() throws Exception {
+        testRemoveServerConfig(true, true, false);
     }
 
     @Test
     public void testRemoveServerConfigSlave() throws Exception {
-        testRemoveServerConfig(false, false);
+        testRemoveServerConfig(false, false, false);
+    }
+
+    @Test
+    public void testRemoveServerConfigCdc() throws Exception {
+        testRemoveServerConfig(false, true, false);
     }
 
     @Test
     public void testRemoveServerConfigMasterRollback() throws Exception {
-        testRemoveServerConfig(true, true);
+        testRemoveServerConfig(true, false, true);
+    }
+
+    @Test
+    public void testRemoveServerConfigMasterCdcRollback() throws Exception {
+        testRemoveServerConfig(true, true, true);
     }
 
     @Test
     public void testRemoveServerConfigSlaveRollback() throws Exception {
-        testRemoveServerConfig(false, true);
+        testRemoveServerConfig(false, false, true);
     }
 
-    private void testRemoveServerConfig(boolean master, boolean rollback) throws Exception {
+    @Test
+    public void testRemoveServerConfigCdcRollback() throws Exception {
+        testRemoveServerConfig(false, true, true);
+    }
+
+    private void testRemoveServerConfig(boolean master, boolean candidateDomainController, boolean rollback) throws Exception {
         PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(HOST, "localhost"), PathElement.pathElement(SERVER_CONFIG, "server-one"));
         final MockOperationContext operationContext = getOperationContext(rollback, pa);
 
@@ -267,26 +327,47 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
 
     @Test
     public void testUpdateServerConfigServerGroupMaster() throws Exception {
-        testUpdateServerConfigServerGroup(true, false, false);
+        testUpdateServerConfigServerGroup(true, false, false, false);
+    }
+
+    @Test
+    public void testUpdateServerConfigServerGroupMasterCdc() throws Exception {
+        testUpdateServerConfigServerGroup(true, true, false, false);
     }
 
     @Test
     public void testUpdateServerConfigServerGroupSlave() throws Exception {
-        testUpdateServerConfigServerGroup(false, false, false);
+        testUpdateServerConfigServerGroup(false, false, false, false);
+
+    }
+
+    @Test
+    public void testUpdateServerConfigServerGroupCdc() throws Exception {
+        testUpdateServerConfigServerGroup(false, true, false, false);
 
     }
 
     @Test
     public void testUpdateServerConfigServerGroupMasterRollback() throws Exception {
-        testUpdateServerConfigServerGroup(true, true, false);
+        testUpdateServerConfigServerGroup(true, false, true, false);
+
+    }
+
+    @Test
+    public void testUpdateServerConfigServerGroupMasterCdcRollback() throws Exception {
+        testUpdateServerConfigServerGroup(true, true, true, false);
 
     }
 
     @Test
     public void testUpdateServerConfigServerGroupSlaveRollback() throws Exception {
-        testUpdateServerConfigServerGroup(false, true, false);
+        testUpdateServerConfigServerGroup(false, false, true, false);
     }
 
+    @Test
+    public void testUpdateServerConfigServerGroupCdcRollback() throws Exception {
+        testUpdateServerConfigServerGroup(false, true, true, false);
+    }
 
 //    // WFCORE-833 moved to ServerConfigTestCase.testChangeServerGroupInvalidServerGroup()
 //    @Test(expected=OperationFailedException.class)
@@ -312,7 +393,7 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
 //        testUpdateServerConfigServerGroup(false, true, true);
 //    }
 
-    private void testUpdateServerConfigServerGroup(boolean master, boolean rollback, boolean badGroup) throws Exception {
+    private void testUpdateServerConfigServerGroup(boolean master, boolean candidateDomainController, boolean rollback, boolean badGroup) throws Exception {
         PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(HOST, "localhost"), PathElement.pathElement(SERVER_CONFIG, "server-one"));
         final MockOperationContext operationContext = getOperationContext(rollback, pa);
 
@@ -334,7 +415,7 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
             throw e;
         }
 
-        if (master && badGroup) {
+        if ((master || candidateDomainController) && badGroup) {
             //master will throw an exception
             Assert.fail();
         }
@@ -344,26 +425,47 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
 
     @Test
     public void testUpdateServerConfigSocketBindingGroupMaster() throws Exception {
-        testUpdateServerConfigSocketBindingGroup(true, false, SocketBindingGroupOverrideType.GOOD);
+        testUpdateServerConfigSocketBindingGroup(true, false, false, SocketBindingGroupOverrideType.GOOD);
+    }
+
+    @Test
+    public void testUpdateServerConfigSocketBindingGroupMasterCdc() throws Exception {
+        testUpdateServerConfigSocketBindingGroup(true, true, false, SocketBindingGroupOverrideType.GOOD);
     }
 
     @Test
     public void testUpdateServerConfigSocketBindingGroupSlave() throws Exception {
-        testUpdateServerConfigSocketBindingGroup(false, false, SocketBindingGroupOverrideType.GOOD);
+        testUpdateServerConfigSocketBindingGroup(false, false, false, SocketBindingGroupOverrideType.GOOD);
+
+    }
+
+    @Test
+    public void testUpdateServerConfigSocketBindingGroupCdc() throws Exception {
+        testUpdateServerConfigSocketBindingGroup(false, true, false, SocketBindingGroupOverrideType.GOOD);
 
     }
 
     @Test
     public void testUpdateServerConfigSocketBindingGroupMasterRollback() throws Exception {
-        testUpdateServerConfigSocketBindingGroup(true, true, SocketBindingGroupOverrideType.GOOD);
+        testUpdateServerConfigSocketBindingGroup(true, false, true, SocketBindingGroupOverrideType.GOOD);
+
+    }
+
+    @Test
+    public void testUpdateServerConfigSocketBindingGroupMasterCdcRollback() throws Exception {
+        testUpdateServerConfigSocketBindingGroup(true, true, true, SocketBindingGroupOverrideType.GOOD);
 
     }
 
     @Test
     public void testUpdateServerConfigSocketBindingGroupSlaveRollback() throws Exception {
-        testUpdateServerConfigSocketBindingGroup(false, true, SocketBindingGroupOverrideType.GOOD);
+        testUpdateServerConfigSocketBindingGroup(false, false, true, SocketBindingGroupOverrideType.GOOD);
     }
 
+    @Test
+    public void testUpdateServerConfigSocketBindingGroupCdcRollback() throws Exception {
+        testUpdateServerConfigSocketBindingGroup(false, true, true, SocketBindingGroupOverrideType.GOOD);
+    }
 
 //    // WFCORE-833 moved to ServerConfigTestCase.testChangeServerGroupInvalidSocketBindingGroup()
 //    @Test(expected=OperationFailedException.class)
@@ -391,25 +493,45 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
 
     @Test
     public void testUpdateServerConfigNoSocketBindingGroupMaster() throws Exception {
-        testUpdateServerConfigSocketBindingGroup(true, false, SocketBindingGroupOverrideType.NONE);
+        testUpdateServerConfigSocketBindingGroup(true, false, false, SocketBindingGroupOverrideType.NONE);
+    }
+
+    @Test
+    public void testUpdateServerConfigNoSocketBindingGroupMasterCdc() throws Exception {
+        testUpdateServerConfigSocketBindingGroup(true, true, false, SocketBindingGroupOverrideType.NONE);
     }
 
     @Test
     public void testUpdateServerConfigNoSocketBindingGroupSlave() throws Exception {
-        testUpdateServerConfigSocketBindingGroup(false, false, SocketBindingGroupOverrideType.NONE);
+        testUpdateServerConfigSocketBindingGroup(false, false, false, SocketBindingGroupOverrideType.NONE);
+    }
+
+    @Test
+    public void testUpdateServerConfigNoSocketBindingGroupCdc() throws Exception {
+        testUpdateServerConfigSocketBindingGroup(false, true, false, SocketBindingGroupOverrideType.NONE);
     }
 
     @Test
     public void testUpdateServerConfigNoSocketBindingGroupMasterRollback() throws Exception {
-        testUpdateServerConfigSocketBindingGroup(true, true, SocketBindingGroupOverrideType.NONE);
+        testUpdateServerConfigSocketBindingGroup(true, false, true, SocketBindingGroupOverrideType.NONE);
+    }
+
+    @Test
+    public void testUpdateServerConfigNoSocketBindingGroupMasterCdcRollback() throws Exception {
+        testUpdateServerConfigSocketBindingGroup(true, true, true, SocketBindingGroupOverrideType.NONE);
     }
 
     @Test
     public void testUpdateServerConfigNoSocketBindingGroupSlaveRollback() throws Exception {
-        testUpdateServerConfigSocketBindingGroup(false, true, SocketBindingGroupOverrideType.NONE);
+        testUpdateServerConfigSocketBindingGroup(false, false, true, SocketBindingGroupOverrideType.NONE);
     }
 
-    private void testUpdateServerConfigSocketBindingGroup(boolean master, boolean rollback, SocketBindingGroupOverrideType socketBindingGroupOverride) throws Exception {
+    @Test
+    public void testUpdateServerConfigNoSocketBindingGroupCdcRollback() throws Exception {
+        testUpdateServerConfigSocketBindingGroup(false, true, true, SocketBindingGroupOverrideType.NONE);
+    }
+
+    private void testUpdateServerConfigSocketBindingGroup(boolean master, boolean candidateDomainController, boolean rollback, SocketBindingGroupOverrideType socketBindingGroupOverride) throws Exception {
 
         PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(HOST, "localhost"), PathElement.pathElement(SERVER_CONFIG, "server-one"));
         final MockOperationContext operationContext = getOperationContext(rollback, pa);
@@ -454,8 +576,11 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
 
     private static class MockHostControllerInfo implements LocalHostControllerInfo {
         private final boolean master;
-        public MockHostControllerInfo(boolean master) {
+        private final boolean candidateDomainController;
+
+        public MockHostControllerInfo(boolean master, boolean candidateDomainController) {
             this.master = master;
+            this.candidateDomainController = candidateDomainController;
         }
 
         @Override
@@ -466,6 +591,11 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
         @Override
         public boolean isMasterDomainController() {
             return master;
+        }
+
+        @Override
+        public boolean isCandidateDomainController() {
+            return candidateDomainController;
         }
 
         @Override


### PR DESCRIPTION
- Add isCandidateDomainController() to LHCI
- Ensure CDCs don't ignore anything
- Ensure CDCs can't get a different config file when using reload command, but single domain masters still can.
- reject slaves with newer API versions from registering
- Note the related (but independent fix for slaves getting an exception during registration here: https://github.com/wildfly/wildfly-core/pull/1881)
