### PR TITLE
[WFCORE-3179] Ensure the pattern-filter that's used to ensure that only the "GS2-KRB5" mechanism gets offered by the server doesn't match on the "GS2-KRB5-PLUS" mechanism name

### DIFF
--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosHttpMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosHttpMgmtSaslTestCase.java
@@ -106,11 +106,12 @@ public class KerberosHttpMgmtSaslTestCase extends AbstractKerberosMgmtSaslTestBa
      * @throws Exception
      */
     private void configurePatternFilter(String mechanism) throws Exception {
+        String patternFilter = mechanism + "$";
         ModelNode op = Util.createEmptyOperation("write-attribute",
                 PathAddress.pathAddress().append("subsystem", "elytron").append("configurable-sasl-server-factory", NAME));
         op.get("name").set("filters");
         ModelNode newValue = new ModelNode();
-        newValue.get("pattern-filter").set(mechanism);
+        newValue.get("pattern-filter").set(patternFilter);
         op.get("value").add(newValue);
         CoreUtils.applyUpdate(op, client);
     }

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosNativeMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosNativeMgmtSaslTestCase.java
@@ -79,10 +79,11 @@ public class KerberosNativeMgmtSaslTestCase extends AbstractKerberosMgmtSaslTest
      */
     @Override
     protected AutoCloseable configureSaslMechanismOnServer(String mechanism, boolean withSsl) throws Exception {
+        String patternFilter = mechanism + "\\$";
         try (CLIWrapper cli = new CLIWrapper(true)) {
             cli.sendLine(String.format(
                     "/subsystem=elytron/configurable-sasl-server-factory=%s:write-attribute(name=filters, value=[{pattern-filter=%s}])",
-                    NAME, mechanism));
+                    NAME, patternFilter));
             String sslContextCli = withSsl ? String.format(
                     "/core-service=management/management-interface=native-interface:write-attribute(name=ssl-context, value=%s)",
                     NAME) : "/core-service=management/management-interface=native-interface:write-attribute(name=ssl-context)";


### PR DESCRIPTION
Fixed the test issue that is causing testGs2Krb5OverSsl() to fail.